### PR TITLE
Fix: Require squizlabs/php_codesniffer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: php
 
-php:
-  - '5.5'
-  - '5.6'
-  - '7.0'
-  - '7.1'
-  - hhvm
+matrix:
+  include:
+    - php: 5.5
+      env: WITH_CS=true
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: hhvm
 
 dist: trusty
 sudo: false

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "facebook/facebook-instant-articles-sdk-php": "^1.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^4.8",
+        "squizlabs/php_codesniffer": "^3.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b5add67aa5284f095c0e347b2a704d1b",
+    "content-hash": "95cfff5c3a7c6603b028a454e0fc7259",
     "packages": [
         {
             "name": "apache/log4php",
@@ -1210,6 +1210,57 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2015-06-21T13:59:46+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "b95ff2c3b122a3ee4b57d149a57d2afce65522c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b95ff2c3b122a3ee4b57d149a57d2afce65522c3",
+                "reference": "b95ff2c3b122a3ee4b57d149a57d2afce65522c3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2017-05-04T00:33:04+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/src/Facebook/InstantArticles/AMP/AMPCoverImage.php
+++ b/src/Facebook/InstantArticles/AMP/AMPCoverImage.php
@@ -75,7 +75,6 @@ class AMPCoverImage
             ->addProperty("div.$containerCSSClass", 'width', AMPContext::DEFAULT_WIDTH.'px')
             ->addProperty("div.$containerCSSClass", 'height', AMPContext::DEFAULT_HEIGHT.'px')
             ->addProperty("div.$containerCSSClass", 'overflow', 'hidden');
-
     }
 
     public function build()

--- a/tests/Facebook/InstantArticles/AMP/AMPCaptionTest.php
+++ b/tests/Facebook/InstantArticles/AMP/AMPCaptionTest.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\AMP;
 
-
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Header;
 use Facebook\InstantArticles\Elements\Image;

--- a/tests/Facebook/InstantArticles/AMP/AMPContextTest.php
+++ b/tests/Facebook/InstantArticles/AMP/AMPContextTest.php
@@ -12,8 +12,6 @@ use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Paragraph;
 use PHPUnit\Framework;
 
-
-
 class AMPContextTest extends Framework\TestCase
 {
     protected function setUp()

--- a/tests/Facebook/InstantArticles/AMP/AMPCoverImageTest.php
+++ b/tests/Facebook/InstantArticles/AMP/AMPCoverImageTest.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\AMP;
 
-
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Header;
 use Facebook\InstantArticles\Elements\Image;

--- a/tests/Facebook/InstantArticles/Utils/Greeting.php
+++ b/tests/Facebook/InstantArticles/Utils/Greeting.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\Utils;
 
-
 /*
  * Sample class used for testing the Observer.
  */

--- a/tests/Facebook/InstantArticles/Utils/ObserverTest.php
+++ b/tests/Facebook/InstantArticles/Utils/ObserverTest.php
@@ -44,7 +44,6 @@ class ObserverTest extends Framework\TestCase
         $observer = Observer::create();
         $observer->addFilter('name', function ($name) {
             return "$name-san";
-
         });
         $name = $observer->applyFilters('name', "Bob");
         $this->assertEquals('Bob-san', $name);


### PR DESCRIPTION
This PR

* [x] requires `squizlabs/php_codesniffer`
* [x] actually runs `phpcs` on Travis
* [x] runs `composer cs`

💁‍♂️ [`CONTRIBUTING.md`](https://github.com/facebook/facebook-instant-articles-sdk-extensions-in-php/blob/8f5b26bfd6d191a2e276d628cd85ccf4ecdfec95/CONTRIBUTING.md#running-php-code-sniffer) suggests to run 

```
$ vendor/bin/phpcs --standard=phpcs.xml -p
```

or

```
$ vendor/bin/phpcbf --standard-phpcs.xml -p
```

and [`README.md`](https://github.com/facebook/facebook-instant-articles-sdk-extensions-in-php/blob/8f5b26bfd6d191a2e276d628cd85ccf4ecdfec95/README.md#contributing) suggests to run

```
$ composer cs
```

but it's just not installed, so it fails with

```
> composer install
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Nothing to install or update
Generating autoload files
> phpcbf --standard=phpcs.xml -p || phpcs --standard=phpcs.xml -p
sh: phpcbf: command not found
sh: phpcs: command not found
Script phpcbf --standard=phpcs.xml -p || phpcs --standard=phpcs.xml -p handling the cs event returned with error code 127
```

