### PR TITLE
Fix: Reference phpunit.xsd as installed with composer

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     bootstrap="vendor/autoload.php"
     colors="true"
 >


### PR DESCRIPTION
This PR

* [x] references `phpunit.xsd` as installed with `composer`

💁‍♂️ This way it points always to the relevant schema file, regardless of which version is installed.