### PR TITLE
Fix: Remove unused imports

### DIFF
--- a/src/Facebook/InstantArticles/AMP/AMPArticle.php
+++ b/src/Facebook/InstantArticles/AMP/AMPArticle.php
@@ -27,7 +27,6 @@ use Facebook\InstantArticles\Elements\Interactive;
 use Facebook\InstantArticles\Elements\SocialEmbed;
 use Facebook\InstantArticles\Elements\Map;
 use Facebook\InstantArticles\Elements\RelatedArticles;
-use Facebook\InstantArticles\Elements\Container;
 use Facebook\InstantArticles\Elements\TextContainer;
 use Facebook\InstantArticles\Elements\InstantArticleInterface;
 use Facebook\InstantArticles\Elements\InstantArticle;
@@ -35,7 +34,6 @@ use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Parser\Parser;
 use Facebook\InstantArticles\Validators\Type;
 use Facebook\InstantArticles\Utils\Observer;
-use Facebook\InstantArticles\Utils\Warning;
 
 class AMPArticle extends Element implements InstantArticleInterface
 {

--- a/src/Facebook/InstantArticles/AMP/AMPCaption.php
+++ b/src/Facebook/InstantArticles/AMP/AMPCaption.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\AMP;
 
-use Facebook\InstantArticles\Validators\Type;
 use Facebook\InstantArticles\Elements\Caption;
 
 class AMPCaption

--- a/src/Facebook/InstantArticles/AMP/AMPContext.php
+++ b/src/Facebook/InstantArticles/AMP/AMPContext.php
@@ -10,7 +10,6 @@ namespace Facebook\InstantArticles\AMP;
 
 use Facebook\InstantArticles\Elements\InstantArticle;
 
-use Facebook\InstantArticles\Parser\Parser;
 use Facebook\InstantArticles\Validators\Type;
 use Facebook\InstantArticles\Utils\Warning;
 use Facebook\InstantArticles\Utils\CSSBuilder;

--- a/tests/Facebook/InstantArticles/AMP/AMPArticleTest.php
+++ b/tests/Facebook/InstantArticles/AMP/AMPArticleTest.php
@@ -1,4 +1,4 @@
-<?php
+e<?php
 /**
  * Copyright (c) 2017-present, Facebook, Inc.
  * All rights reserved.
@@ -9,7 +9,6 @@
 namespace Facebook\InstantArticles\AMP;
 
 use Facebook\InstantArticles\Elements\InstantArticle;
-use Facebook\InstantArticles\AMP\AMPArticle;
 use Facebook\InstantArticles\Parser\Parser;
 use Facebook\InstantArticles\Utils\FileUtilsPHPUnitTestCase;
 

--- a/tests/Facebook/InstantArticles/AMP/AMPCaptionTest.php
+++ b/tests/Facebook/InstantArticles/AMP/AMPCaptionTest.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\AMP;
 
-use Facebook\InstantArticles\AMP\AMPContext;
 
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Header;

--- a/tests/Facebook/InstantArticles/AMP/AMPContextTest.php
+++ b/tests/Facebook/InstantArticles/AMP/AMPContextTest.php
@@ -10,11 +10,8 @@ namespace Facebook\InstantArticles\AMP;
 
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Paragraph;
-use Facebook\InstantArticles\AMP\AMPArticle;
-use Facebook\InstantArticles\Parser\Parser;
 
-use Aws\S3\S3Client;
-use Aws\Common\Aws;
+
 
 class AMPContextTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/AMP/AMPCoverImageTest.php
+++ b/tests/Facebook/InstantArticles/AMP/AMPCoverImageTest.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\AMP;
 
-use Facebook\InstantArticles\AMP\AMPContext;
 
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Header;

--- a/tests/Facebook/InstantArticles/AMP/AMPHeaderTest.php
+++ b/tests/Facebook/InstantArticles/AMP/AMPHeaderTest.php
@@ -8,9 +8,6 @@
  */
 namespace Facebook\InstantArticles\AMP;
 
-use Facebook\InstantArticles\AMP\AMPHeader;
-use Facebook\InstantArticles\AMP\AMPImage;
-use Facebook\InstantArticles\AMP\AMPArticle;
 use Facebook\InstantArticles\Utils\FileUtilsPHPUnitTestCase;
 
 class AMPHeaderTest extends FileUtilsPHPUnitTestCase

--- a/tests/Facebook/InstantArticles/Utils/CSSBuilderTest.php
+++ b/tests/Facebook/InstantArticles/Utils/CSSBuilderTest.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\Utils;
 
-use Facebook\InstantArticles\Validators\Type;
 
 class CSSBuilderTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Facebook/InstantArticles/Utils/Greeting.php
+++ b/tests/Facebook/InstantArticles/Utils/Greeting.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\Utils;
 
-use Facebook\InstantArticles\Validators\Type;
 
 /*
  * Sample class used for testing the Observer.

--- a/tests/Facebook/InstantArticles/Utils/ObserverTest.php
+++ b/tests/Facebook/InstantArticles/Utils/ObserverTest.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\Utils;
 
-use Facebook\InstantArticles\Validators\Type;
 
 class ObserverTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
This PR

* [x] removes unused imports

💁‍♂️ Ran

```
$ composer global require friendsofphp/php-cs-fixer
```

and then

```
$ php-cs-fixer fix --using-cache=no --rules=no_unused_imports src && php-cs-fixer fix --using-cache=no --rules=no_unused_imports tests
```