### PR TITLE
Fix: Run build on PHP 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: php
 matrix:
   include:
     - php: 5.4
-    - php: 5.5
       env: WITH_CS=true
+    - php: 5.5
     - php: 5.6
     - php: 7.0
     - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 matrix:
   include:
+    - php: 5.4
     - php: 5.5
       env: WITH_CS=true
     - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ install:
   - travis_retry composer install --no-interaction --prefer-dist
 
 script:
-  - vendor/bin/phpunit
   - if [[ "$WITH_CS" == "true" ]]; then vendor/bin/phpcs --standard=phpcs.xml -p; fi
+  - vendor/bin/phpunit


### PR DESCRIPTION
This PR

* [x] runs a build on PHP 5.4 on Travis
* [x] runs `phpcs` on PHP 5.4
* [x] runs `phpcs` before tests (to ensure we don't apply any fixes incompatible with the PHP version)


💁‍♂️ [`composer.json`](https://github.com/facebook/facebook-instant-articles-sdk-extensions-in-php/blob/8f5b26bfd6d191a2e276d628cd85ccf4ecdfec95/composer.json#L13) suggests it is supported, so we should run a build on it, shouldn't we?