### PR TITLE
Fix: Use forward compatibility layer of phpunit/phpunit

### DIFF
--- a/tests/Facebook/InstantArticles/AMP/AMPCaptionTest.php
+++ b/tests/Facebook/InstantArticles/AMP/AMPCaptionTest.php
@@ -15,8 +15,9 @@ use Facebook\InstantArticles\Elements\Image;
 use Facebook\InstantArticles\Elements\Time;
 use Facebook\InstantArticles\Elements\Author;
 use Facebook\InstantArticles\Elements\Caption;
+use PHPUnit\Framework;
 
-class AMPCaptionTest extends \PHPUnit_Framework_TestCase
+class AMPCaptionTest extends Framework\TestCase
 {
 
     protected function setUp()

--- a/tests/Facebook/InstantArticles/AMP/AMPContextTest.php
+++ b/tests/Facebook/InstantArticles/AMP/AMPContextTest.php
@@ -10,10 +10,11 @@ namespace Facebook\InstantArticles\AMP;
 
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Paragraph;
+use PHPUnit\Framework;
 
 
 
-class AMPContextTest extends \PHPUnit_Framework_TestCase
+class AMPContextTest extends Framework\TestCase
 {
     protected function setUp()
     {

--- a/tests/Facebook/InstantArticles/AMP/AMPCoverImageTest.php
+++ b/tests/Facebook/InstantArticles/AMP/AMPCoverImageTest.php
@@ -15,8 +15,9 @@ use Facebook\InstantArticles\Elements\Image;
 use Facebook\InstantArticles\Elements\Time;
 use Facebook\InstantArticles\Elements\Author;
 use Facebook\InstantArticles\Elements\Caption;
+use PHPUnit\Framework;
 
-class AMPCoverImageTest extends \PHPUnit_Framework_TestCase
+class AMPCoverImageTest extends Framework\TestCase
 {
 
     protected function setUp()

--- a/tests/Facebook/InstantArticles/Utils/CSSBuilderTest.php
+++ b/tests/Facebook/InstantArticles/Utils/CSSBuilderTest.php
@@ -8,8 +8,9 @@
  */
 namespace Facebook\InstantArticles\Utils;
 
+use PHPUnit\Framework;
 
-class CSSBuilderTest extends \PHPUnit_Framework_TestCase
+class CSSBuilderTest extends Framework\TestCase
 {
     protected function setUp()
     {

--- a/tests/Facebook/InstantArticles/Utils/FileUtilsPHPUnitTestCase.php
+++ b/tests/Facebook/InstantArticles/Utils/FileUtilsPHPUnitTestCase.php
@@ -9,8 +9,9 @@
 namespace Facebook\InstantArticles\Utils;
 
 use Facebook\InstantArticles\Parser\Parser;
+use PHPUnit\Framework;
 
-class FileUtilsPHPUnitTestCase extends \PHPUnit_Framework_TestCase
+class FileUtilsPHPUnitTestCase extends Framework\TestCase
 {
     protected function setUp()
     {

--- a/tests/Facebook/InstantArticles/Utils/HookTest.php
+++ b/tests/Facebook/InstantArticles/Utils/HookTest.php
@@ -9,8 +9,9 @@
 namespace Facebook\InstantArticles\Utils;
 
 use Facebook\InstantArticles\Validators\Type;
+use PHPUnit\Framework;
 
-class HookTest extends \PHPUnit_Framework_TestCase
+class HookTest extends Framework\TestCase
 {
     protected function setUp()
     {

--- a/tests/Facebook/InstantArticles/Utils/ObserverTest.php
+++ b/tests/Facebook/InstantArticles/Utils/ObserverTest.php
@@ -8,8 +8,9 @@
  */
 namespace Facebook\InstantArticles\Utils;
 
+use PHPUnit\Framework;
 
-class ObserverTest extends \PHPUnit_Framework_TestCase
+class ObserverTest extends Framework\TestCase
 {
     protected function setUp()
     {


### PR DESCRIPTION
This PR

* [x] makes use of the forward compatibility layer of `phpunit/phpunit`