### PR TITLE
Fix: Actually use encoding

### DIFF
--- a/tests/Facebook/InstantArticles/Utils/FileUtilsPHPUnitTestCase.php
+++ b/tests/Facebook/InstantArticles/Utils/FileUtilsPHPUnitTestCase.php
@@ -60,7 +60,7 @@ class FileUtilsPHPUnitTestCase extends \PHPUnit_Framework_TestCase
     {
         libxml_use_internal_errors(true);
         $document = new \DOMDocument('1.0');
-        $document->loadHTML('<?xml encoding="${$encoding}" ?>'.$fileContent);
+        $document->loadHTML('<?xml encoding="' . $encoding. '"?>'.$fileContent);
         libxml_use_internal_errors(false);
         return $document;
     }


### PR DESCRIPTION
This PR

* [x] adjusts a `string` argument to actually make use of a parameter referencing the encoding