### PR TITLE
Fix: Disallow long array syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: php
 
-php:
-  - '5.5'
-  - '5.6'
-  - '7.0'
-  - '7.1'
-  - hhvm
+matrix:
+  include:
+    - php: 5.5
+      env: WITH_CS=true
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: hhvm
 
 dist: trusty
 sudo: false

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "facebook/facebook-instant-articles-sdk-php": "^1.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^4.8",
+        "squizlabs/php_codesniffer": "^3.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b5add67aa5284f095c0e347b2a704d1b",
+    "content-hash": "95cfff5c3a7c6603b028a454e0fc7259",
     "packages": [
         {
             "name": "apache/log4php",
@@ -1210,6 +1210,57 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2015-06-21T13:59:46+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "b95ff2c3b122a3ee4b57d149a57d2afce65522c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b95ff2c3b122a3ee4b57d149a57d2afce65522c3",
+                "reference": "b95ff2c3b122a3ee4b57d149a57d2afce65522c3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2017-05-04T00:33:04+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/examples/example-override-styling.php
+++ b/examples/example-override-styling.php
@@ -20,10 +20,10 @@ $instant_article_string = file_get_contents(__DIR__.'/instant-article-example.ht
 // Loads from a file or even you could load from the graph API style Editor.
 $styleGotFromSomewhereElse = file_get_contents(__DIR__.'/styles/style-got-from-somewhereelse.json');
 
-$properties = array(
+$properties = [
     // Overrides any style linked from the Instant Article, this might be useful if you want to apply a different style than the one in specified Instant Articles.
     'override-styles' => json_decode($styleGotFromSomewhereElse, true)
-);
+];
 
 // Converts it into AMP
 $amp_string = AMPArticle::create($instant_article_string, $properties)->render();

--- a/examples/example-quick-start.php
+++ b/examples/example-quick-start.php
@@ -21,18 +21,18 @@ $instant_article_string = file_get_contents(__DIR__.'/instant-article-example.ht
 // it's markup but the AMP spec requires everything to have explicit sizing.
 
 // This will hold our custom properties
-$properties = array();
+$properties = [];
 
 // Videos require explicit sizing, if you fail to provide it, the default values
 // may distort your Videos
 $properties[AMPArticle::MEDIA_SIZES_KEY]
-  ['http://mydomain.com/path/to/video.mp4'] = array(320, 240);
+  ['http://mydomain.com/path/to/video.mp4'] = [320, 240];
 
 // Images can also be passed
 // IMPORTANT: The image will not have fixed-width, but it will respect the
 //            aspect ration provided here. They are using the responsive layout
 $properties[AMPArticle::MEDIA_SIZES_KEY]
-  ['http://mydomain.com/path/to/crazy.jpg'] = array(640, 480);
+  ['http://mydomain.com/path/to/crazy.jpg'] = [640, 480];
 
 // The SDK can automatically download the images and get their sizes if they are not
 // in the array above, if you enable the following option.
@@ -52,10 +52,10 @@ $properties[AMPArticle::ENABLE_DOWNLOAD_FOR_MEDIA_SIZING_KEY] = true;
 // See also the AMP specs for these tags:
 // - https://www.ampproject.org/docs/reference/components/amp-analytics
 // - https://www.ampproject.org/docs/reference/components/amp-pixel
-$properties[AMPArticle::ANALYTICS_KEY] = array(
+$properties[AMPArticle::ANALYTICS_KEY] = [
   '<amp-pixel src="http://mydomain.com/my_tracking_pixel.gif">',
   '<amp-analytics config="https://mydomain.com/analytics.config.json"></amp-analytics>'
-);
+];
 
 // Converts it into AMP
 $amp_string =

--- a/examples/example-simple-styling.php
+++ b/examples/example-simple-styling.php
@@ -16,10 +16,10 @@ include __DIR__ . '/quiet_logger.php';
 
  // Load instant article file into string
 $instant_article_string = file_get_contents(__DIR__.'/instant-article-example.html');
-$properties = array(
+$properties = [
   'lang' => 'en-US',                   // You can set the language your article have
   'styles-folder' => __DIR__.'/styles' // Where the styles are stored
-);
+];
 
 /*
   As the name of the style used within the Instant article refers to <code>"gray"</code>, the

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,4 +5,5 @@
     <arg name="colors" />
     <arg value="sn" />
     <rule ref="PSR2"  />
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax.Found" />
 </ruleset>

--- a/src/Facebook/InstantArticles/AMP/AMPArticle.php
+++ b/src/Facebook/InstantArticles/AMP/AMPArticle.php
@@ -76,7 +76,7 @@ class AMPArticle extends Element implements InstantArticleInterface
        'publisher' => array(),
        'analytics' => array(),
      */
-    private $properties = array();
+    private $properties = [];
 
     /**
      * @var Observer The instance for Observing and Hooking system for extensions
@@ -102,7 +102,7 @@ class AMPArticle extends Element implements InstantArticleInterface
      * @param array() $properties the configuration for the AMP conversion. @see https://developers.facebook.com/docs/instant-articles/other-formats
      * @param Observer $observer optional, will be created in case none informed. This is the hooking system for code level customizations.
      */
-    public static function create($instantArticle, $properties = array(), $observer = null)
+    public static function create($instantArticle, $properties = [], $observer = null)
     {
         // Treats if the informed content is string, parsing it into InstantArticle.
         if (Type::is($instantArticle, Type::STRING)) {
@@ -119,7 +119,7 @@ class AMPArticle extends Element implements InstantArticleInterface
         Type::enforce($instantArticle, InstantArticle::getClassName());
 
         if ($properties === null) {
-            $properties = array();
+            $properties = [];
         }
 
         if ($observer == null) {
@@ -242,7 +242,7 @@ class AMPArticle extends Element implements InstantArticleInterface
     public function transformInstantArticle($context)
     {
         // Builds and appends head to the HTML document
-        $html = $context->createElement('html', null, null, array("amp" => ""));
+        $html = $context->createElement('html', null, null, ["amp" => ""]);
         if ($context->getInstantArticle()->isRTLEnabled()) {
             $html->setAttribute('dir', 'rtl');
         }
@@ -306,7 +306,7 @@ class AMPArticle extends Element implements InstantArticleInterface
 
         // Builds meta charset and append to head
         if ($context->getInstantArticle()->getCharset()) {
-            $context->createElement('meta', $head, null, array('charset' => $context->getInstantArticle()->getCharset()));
+            $context->createElement('meta', $head, null, ['charset' => $context->getInstantArticle()->getCharset()]);
         }
 
         // Builds meta viewport and append to head
@@ -314,28 +314,28 @@ class AMPArticle extends Element implements InstantArticleInterface
             'meta',
             $head,
             null,
-            array(
+            [
                 'name' => 'viewport',
                 'content' => 'width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no'
-            )
+            ]
         );
 
         // Builds ampjs script and append to head
-        $context->createElement('script', $head, null, array('src' => 'https://cdn.ampproject.org/v0.js', 'async' => ''));
+        $context->createElement('script', $head, null, ['src' => 'https://cdn.ampproject.org/v0.js', 'async' => '']);
 
         // Builds boilerplate css style and append to head
-        $boilerplate = $context->createElement('style', $head, null, array('amp-boilerplate' => ''));
+        $boilerplate = $context->createElement('style', $head, null, ['amp-boilerplate' => '']);
         $boilerplateContent = $context->getDocument()->createTextNode('body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}');
         $boilerplate->appendChild($boilerplateContent);
 
         // Builds noscript css style and append to head
         $noscript = $context->createElement('noscript', $head);
-        $noscriptBoilerplate = $context->createElement('style', $noscript, null, array('amp-boilerplate' => ''));
+        $noscriptBoilerplate = $context->createElement('style', $noscript, null, ['amp-boilerplate' => '']);
         $noscriptBoilerplateContent = $context->getDocument()->createTextNode('body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}');
         $noscriptBoilerplate->appendChild($noscriptBoilerplateContent);
 
         // Builds canonical link and append to head
-        $link = $context->createElement('link', $head, null, array('rel' => 'canonical', 'href' => $context->getInstantArticle()->getCanonicalURL()));
+        $link = $context->createElement('link', $head, null, ['rel' => 'canonical', 'href' => $context->getInstantArticle()->getCanonicalURL()]);
 
         // Builds custom css style and append to head
         $ampCustomCSS = $this->buildCustomCSS($context);
@@ -344,7 +344,7 @@ class AMPArticle extends Element implements InstantArticleInterface
         $this->customCSSElement = $ampCustomCSS;
 
         // Builds Schema.org metadata and appends to head
-        $discoveryScript = $context->createElement('script', $head, null, array('type' => 'application/ld+json'));
+        $discoveryScript = $context->createElement('script', $head, null, ['type' => 'application/ld+json']);
         $discoveryScriptContent = $this->buildSchemaOrgMetadata($context);
         $discoveryScript->appendChild($context->getDocument()->createTextNode($discoveryScriptContent));
 
@@ -716,7 +716,7 @@ class AMPArticle extends Element implements InstantArticleInterface
             $ampCaptionCredit->appendChild($ampCreditText);
         }
 
-        $ampCSSClasses = array();
+        $ampCSSClasses = [];
         $ampCSSClasses[] = $context->buildCssClass('figcaption');
 
         if ($caption->getFontSize()) {
@@ -938,7 +938,7 @@ class AMPArticle extends Element implements InstantArticleInterface
             ? $this->properties[self::DEFAULT_MEDIA_HEIGHT_KEY]
             : self::DEFAULT_HEIGHT;
 
-        return array($width, $height);
+        return [$width, $height];
     }
 
     private function getMediaDimensionsFromCache($mediaURL)
@@ -990,17 +990,17 @@ class AMPArticle extends Element implements InstantArticleInterface
 
         if (file_exists($stylesFolder . 'global.amp-custom.css')) {
             $globalCSSFile = file_get_contents($stylesFolder . 'global.amp-custom.css');
-            $globalCSSFile = str_replace(array("\r", "\n"), ' ', $globalCSSFile);
+            $globalCSSFile = str_replace(["\r", "\n"], ' ', $globalCSSFile);
         }
 
         if (file_exists($stylesFolder . $styleName . '.amp-custom.css')) {
             $customCSSFile = file_get_contents($stylesFolder . $styleName . '.amp-custom.css');
-            $customCSSFile = str_replace(array("\r", "\n"), ' ', $customCSSFile);
+            $customCSSFile = str_replace(["\r", "\n"], ' ', $customCSSFile);
         }
 
         if (!isset($globalCSSFile) && !isset($customCSSFile)) {
             $defaultCSSFile = file_get_contents(__DIR__ . '/configuration/global.amp.css');
-            $defaultCSSFile = str_replace(array("\r", "\n"), ' ', $defaultCSSFile);
+            $defaultCSSFile = str_replace(["\r", "\n"], ' ', $defaultCSSFile);
         }
 
         $this->articleColorsStyles($styles, $context);
@@ -1024,20 +1024,20 @@ class AMPArticle extends Element implements InstantArticleInterface
 
     private function articleHeadStyles($styles, $context)
     {
-        $mappings = array(
+        $mappings = [
             $context->buildCssSelector('header-category') => 'kicker',
             $context->buildCssSelector('header-h1') => 'title',
             $context->buildCssSelector('header-h2') => 'subtitle',
             $context->buildCssSelector('header h3') => 'byline'
-        );
+        ];
 
-        $dateFormatMappings = array(
+        $dateFormatMappings = [
             'MONTH_AND_DAY' => 'F d',
             'MONTH_AND_YEAR' => 'F Y',
             'MONTH_DAY_YEAR' => 'F d, Y',
             'YEAR' => 'Y',
             'MONTH_DAY_YEAR_TIME' => 'F d, Y H:i A',
-        );
+        ];
         if (array_key_exists('date_style', $styles)) {
             $dateFormat = $styles['date_style'];
             if (array_key_exists($dateFormat, $dateFormatMappings)) {
@@ -1106,28 +1106,28 @@ class AMPArticle extends Element implements InstantArticleInterface
 
     private function articleBodyStyles($styles, $context)
     {
-        $mappings = array(
+        $mappings = [
             $context->buildCssSelector('h1') => 'primary_heading',
             $context->buildCssSelector('h2') => 'secondary_heading',
             $context->buildCssSelector('p') => 'body_text',
             $context->buildCssSelector('article a') => 'inline_link',
-        );
+        ];
         $this->buildCSSRulesFromMappings($mappings, $styles, $context);
     }
 
     private function articleQuoteStyles($styles, $context)
     {
-        $mappings = array(
+        $mappings = [
             $context->buildCssSelector('blockquote') => 'block_quote',
             $context->buildCssSelector('pullquote') => 'pull_quote',
             $context->buildCssSelector('pullquote cite') => 'pull_quote_attribution',
-        );
+        ];
         $this->buildCSSRulesFromMappings($mappings, $styles, $context);
     }
 
     private function articleCaptionStyles($styles, $context)
     {
-        $mappings = array(
+        $mappings = [
             '.ia2amp-op-small h1' => 'caption_title_small',
             '.ia2amp-op-small h2' => 'caption_description_small',
 
@@ -1141,32 +1141,32 @@ class AMPArticle extends Element implements InstantArticleInterface
             '.ia2amp-op-extra-large h2' => 'caption_description_extra_large',
 
             '.ia2amp-figcaption cite' => 'caption_credit',
-        );
+        ];
         $this->buildCSSRulesFromMappings($mappings, $styles, $context);
     }
 
     private function articleFooterStyles($styles, $context)
     {
-        $mappings = array(
+        $mappings = [
             $context->buildCssSelector('footer') => 'footer',
-        );
+        ];
         $this->buildCSSRulesFromMappings($mappings, $styles, $context);
     }
 
     private function buildTextCSSDeclarationBlock($selector, $textStyles, $textType, $context)
     {
-        $mappings = array(
+        $mappings = [
             'font-family' => 'font',
             'text-align' => 'text_alignment',
             'display' => 'display',
-        );
+        ];
         $filteredMappings = AMPArticle::filterMappings($mappings, $textStyles);
 
-        $textTransformMappings = array(
+        $textTransformMappings = [
             'ALL_CAPS' => 'uppercase',
             'ALL_LOWER_CASE' => 'lowercase',
             'NONE' => 'none',
-        );
+        ];
         if (array_key_exists('capitalization', $textStyles)) {
             $filteredMappings['text-transform'] = $textTransformMappings[$textStyles['capitalization']];
         }
@@ -1183,7 +1183,7 @@ class AMPArticle extends Element implements InstantArticleInterface
             $filteredMappings['color'] = AMPArticle::toRGB($textStyles['color']);
         }
 
-        $spacingMappings = array(
+        $spacingMappings = [
             'NONE' => 0,
             'DOCUMENT_MARGIN' => AMPArticle::DEFAULT_MARGIN,
             'EXTRA_SMALL' => 16,
@@ -1191,7 +1191,7 @@ class AMPArticle extends Element implements InstantArticleInterface
             'MEDIUM' => 46,
             'LARGE' => 64,
             'EXTRA_LARGE' => 96,
-        );
+        ];
         $marginMappings = AMPArticle::getSpacingDeclarationBlocks($spacingMappings, 'margin', $textStyles);
         $filteredMappings = array_merge($filteredMappings, $marginMappings);
         $paddingMappings = AMPArticle::getSpacingDeclarationBlocks($spacingMappings, 'padding', $textStyles);
@@ -1207,7 +1207,7 @@ class AMPArticle extends Element implements InstantArticleInterface
 
     private static function filterMappings($mappings, $styles)
     {
-        $result = array();
+        $result = [];
         foreach ($mappings as $cssKey => $styleKey) {
             if (array_key_exists($styleKey, $styles)) {
                 $result[$cssKey] = $styles[$styleKey];
@@ -1218,22 +1218,22 @@ class AMPArticle extends Element implements InstantArticleInterface
 
     private static function getSpacingDeclarationBlocks($spacingMappings, $spacingType, $textStyles)
     {
-        $directions = array(
+        $directions = [
             'top',
             'right',
             'bottom',
             'left',
-        );
+        ];
         if (!array_key_exists($spacingType, $textStyles)) {
-            return array();
+            return [];
         }
         $spacingStyles = $textStyles[$spacingType];
-        $spacings = array();
+        $spacings = [];
         foreach ($directions as $direction) {
             $spacing = AMPArticle::getDirectionSpacing($spacingMappings, $direction, $spacingStyles);
             $spacings[] = $spacing != 0 ? $spacing . 'px' : '0';
         }
-        return array($spacingType => implode(' ', $spacings));
+        return [$spacingType => implode(' ', $spacings)];
     }
 
     private function buildCSSRulesFromMappings($mappings, $styles, $context)
@@ -1261,18 +1261,18 @@ class AMPArticle extends Element implements InstantArticleInterface
 
     private static function getBorderDeclarationBlocks($textStyles)
     {
-        $directions = array(
+        $directions = [
             'top',
             'right',
             'bottom',
             'left',
-        );
+        ];
         if (!array_key_exists('border', $textStyles)) {
-            return array();
+            return [];
         }
         $borderStyles = $textStyles['border'];
-        $declarationBlocks = array();
-        $borderWidths = array();
+        $declarationBlocks = [];
+        $borderWidths = [];
         foreach ($directions as $direction) {
             if (array_key_exists($direction, $borderStyles)) {
                 $borderDirectionStyles = $borderStyles[$direction];
@@ -1351,14 +1351,14 @@ class AMPArticle extends Element implements InstantArticleInterface
         $published = $header->getPublished();
         $modified = $header->getModified();
 
-        $metadata = array(
+        $metadata = [
             '@context' => 'http://schema.org',
             '@type' => 'NewsArticle',
             'mainEntityOfPage' => $this->instantArticle->getCanonicalURL(),
             'headline' => $this->instantArticle->getHeader()->getTitle()->getPlainText(),
             'datePublished' => date_format($published->getDatetime(), 'c'),
             'description' => $this->instantArticle->getFirstParagraph()->getPlainText(),
-        );
+        ];
 
         if ($modified) {
             $metadata['dateModified'] = date_format($modified->getDatetime(), 'c');
@@ -1366,10 +1366,10 @@ class AMPArticle extends Element implements InstantArticleInterface
 
         $authors = $header->getAuthors();
         foreach ($authors as $author) {
-            $metadata['author'] = array(
+            $metadata['author'] = [
                 '@type' => 'Person',
                 'name' => $author->getName(),
-            );
+            ];
             break;
         }
 
@@ -1393,10 +1393,10 @@ class AMPArticle extends Element implements InstantArticleInterface
 
         if ($publisher && Type::is($publisher, Type::STRING)) {
             // String values will be treated as organization names
-            $publisher = array(
+            $publisher = [
                 '@type' => 'Organization',
                 'name' => $publisher,
-            );
+            ];
         }
 
         return $publisher;
@@ -1424,12 +1424,12 @@ class AMPArticle extends Element implements InstantArticleInterface
         if ($imageURL) {
             $imageDimensions = $this->getMediaDimensions($imageURL, AMPContext::MEDIA_TYPE_IMAGE);
 
-            return array(
+            return [
                 '@type' => 'ImageObject',
                 'url' => $imageURL,
                 'width' => $imageDimensions[0],
                 'height' => $imageDimensions[1],
-            );
+            ];
         }
 
         return null;

--- a/src/Facebook/InstantArticles/AMP/AMPCaption.php
+++ b/src/Facebook/InstantArticles/AMP/AMPCaption.php
@@ -122,7 +122,7 @@ class AMPCaption
 
     private function applyStyleClasses()
     {
-        $ampCSSClasses = array();
+        $ampCSSClasses = [];
         $ampCSSClasses[] = $this->context->buildCssClass('figcaption');
 
         if ($this->caption->getFontSize()) {

--- a/src/Facebook/InstantArticles/AMP/AMPContext.php
+++ b/src/Facebook/InstantArticles/AMP/AMPContext.php
@@ -30,14 +30,14 @@ class AMPContext
     private $headerAuthor;
     private $headerKicker;
     private $headerDate;
-    private $articleItems = array();
+    private $articleItems = [];
     private $footer;
 
     private $cssPrefix;
     private $previousElementIdentifier;
     private $previousSpacing;
 
-    private $warnings = array();
+    private $warnings = [];
 
     private $cssBuilder;
 
@@ -145,7 +145,7 @@ class AMPContext
     {
         $element = $this->getDocument()->createElement($tagName);
         if (!isset($attributes) || !$attributes) {
-            $attributes = array();
+            $attributes = [];
         }
         if (!Type::isTextEmpty($cssClass)) {
             $attributes['class'] = $this->buildCssClass($cssClass);
@@ -685,7 +685,7 @@ class AMPContext
             }
         }
 
-        return array($this->defaultWidth, $this->defaultHeight);
+        return [$this->defaultWidth, $this->defaultHeight];
     }
 
     private function getMediaDimensionsFromCache($mediaURL)

--- a/src/Facebook/InstantArticles/AMP/AMPCoverImage.php
+++ b/src/Facebook/InstantArticles/AMP/AMPCoverImage.php
@@ -75,7 +75,6 @@ class AMPCoverImage
             ->addProperty("div.$containerCSSClass", 'width', AMPContext::DEFAULT_WIDTH.'px')
             ->addProperty("div.$containerCSSClass", 'height', AMPContext::DEFAULT_HEIGHT.'px')
             ->addProperty("div.$containerCSSClass", 'overflow', 'hidden');
-
     }
 
     public function build()

--- a/src/Facebook/InstantArticles/AMP/AMPHeader.php
+++ b/src/Facebook/InstantArticles/AMP/AMPHeader.php
@@ -110,11 +110,11 @@ class AMPHeader
             'amp-img',
             $ampImageContainer,
             null,
-            array(
+            [
                 'src' => $logo->url,
                 'width' => $logo->width,
                 'height' => $logo->height
-            )
+            ]
         );
     }
 

--- a/src/Facebook/InstantArticles/Utils/CSSBuilder.php
+++ b/src/Facebook/InstantArticles/Utils/CSSBuilder.php
@@ -25,7 +25,7 @@ class CSSBuilder
     /**
      * @var array('string'=>array('string' => properties))
      */
-    private $selectors = array();
+    private $selectors = [];
 
     /**
      * @var string prefix for css selector classes
@@ -56,7 +56,7 @@ class CSSBuilder
         if (isset($this->selectors[$selector])) {
             $selectorProps = $this->selectors[$selector];
         } else {
-            $selectorProps = array();
+            $selectorProps = [];
         }
 
         $selectorProps[$property] = $value;
@@ -138,7 +138,7 @@ class CSSBuilder
     private function buildCssSelector($class)
     {
         if (is_array($class)) {
-            $selectors = array();
+            $selectors = [];
             foreach ($class as $singleClass) {
                 $selectors[] = $this->buildCssSelector($singleClass);
             }

--- a/src/Facebook/InstantArticles/Utils/CallbackHook.php
+++ b/src/Facebook/InstantArticles/Utils/CallbackHook.php
@@ -17,17 +17,17 @@ class CallbackHook implements \Iterator, \ArrayAccess
     /**
      * @var array Callback functions/instance->methods
      */
-    public $callbacks = array();
+    public $callbacks = [];
 
     /**
      * @var array The priority keys of actively running iterations of a hook.
      */
-    private $iterations = array();
+    private $iterations = [];
 
     /**
      * @var array The current priority of actively running iterations of a hook.
      */
-    private $currentPriority = array();
+    private $currentPriority = [];
 
     /**
      * @var int Number of levels this hook can be recursively called.
@@ -49,10 +49,10 @@ class CallbackHook implements \Iterator, \ArrayAccess
     {
         $priorityExisted = isset($this->callbacks[$priority]);
 
-        $this->callbacks[$priority][$idx] = array(
+        $this->callbacks[$priority][$idx] = [
             'function' => $functionToAdd,
             'accepted_args' => $acceptedArgs
-        );
+        ];
 
         // if we're adding a new priority to the list, put them back in sorted order
         if (!$priorityExisted && count($this->callbacks) > 1) {
@@ -208,7 +208,7 @@ class CallbackHook implements \Iterator, \ArrayAccess
         }
 
         if (false === $priority) {
-            $this->callbacks = array();
+            $this->callbacks = [];
         } else if (isset($this->callbacks[$priority])) {
             unset($this->callbacks[$priority]);
         }
@@ -244,7 +244,7 @@ class CallbackHook implements \Iterator, \ArrayAccess
 
                 // Avoid the array_slice if possible.
                 if ($callbackPriority['accepted_args'] == 0) {
-                    $value = call_user_func_array($callbackPriority['function'], array());
+                    $value = call_user_func_array($callbackPriority['function'], []);
                 } elseif ($callbackPriority['accepted_args'] >= $num_args) {
                     $value = call_user_func_array($callbackPriority['function'], $args);
                 } else {

--- a/src/Facebook/InstantArticles/Utils/Hook.php
+++ b/src/Facebook/InstantArticles/Utils/Hook.php
@@ -23,16 +23,16 @@ namespace Facebook\InstantArticles\Utils;
 class Hook
 {
     /* Hooks to have overriden callable */
-    private $hooks = array();
-    private $params = array();
+    private $hooks = [];
+    private $params = [];
 
     /* Hooks to have before callable */
-    private $beforeHooks = array();
-    private $beforeParams = array();
+    private $beforeHooks = [];
+    private $beforeParams = [];
 
     /* Hooks to have after callable */
-    private $afterHooks = array();
-    private $afterParams = array();
+    private $afterHooks = [];
+    private $afterParams = [];
 
     /**
      * Private constructor to force factory method: Hook::create();
@@ -121,12 +121,12 @@ class Hook
      * @param string/array $callable The string method to be called or array with array('Namespace.ClassName', 'methodName')
      * @param array(mixed) The params to be used into your methodName from your callable.
      */
-    public function call($hookName, $callable, $params = array())
+    public function call($hookName, $callable, $params = [])
     {
         // Treats before hook is called. To set something to happen before any hook, just use setBeforeHook('hook_name', ...)
         if (array_key_exists($hookName, $this->beforeHooks) && isset($this->beforeHooks[$hookName])) {
             $beforeCallable = $this->beforeHooks[$hookName];
-            $beforeParams = array();
+            $beforeParams = [];
             if (array_key_exists($hookName, $this->beforeParams) && isset($this->beforeParams[$hookName])) {
                 $beforeParams = $this->beforeParams[$hookName];
             }
@@ -147,7 +147,7 @@ class Hook
         // Treats after hook is called. To set something to happen after any hook, just use setAfterHook('hook_name', ...)
         if (array_key_exists($hookName, $this->afterHooks) && isset($this->afterHooks[$hookName])) {
             $afterCallable = $this->afterHooks[$hookName];
-            $afterParams = array();
+            $afterParams = [];
             if (array_key_exists($hookName, $this->afterParams) && isset($this->afterParams[$hookName])) {
                 $afterParams = $this->afterParams[$hookName];
             }

--- a/src/Facebook/InstantArticles/Utils/Observer.php
+++ b/src/Facebook/InstantArticles/Utils/Observer.php
@@ -27,7 +27,7 @@ class Observer
     private static $filterCount = 0;
 
     /* Filters configured. Mapped array: 'filter name' => CallbackHolder  */
-    private $callbacks = array();
+    private $callbacks = [];
 
     /**
      * Private constructor to force factory method: Hook::create();
@@ -144,7 +144,7 @@ class Observer
      */
     public function applyFilters($tag, $value/*, $var...*/)
     {
-        $args = array();
+        $args = [];
 
         // In case no filters configured for this hook, simply return informed value.
         if (!isset($this->callbacks[$tag])) {
@@ -238,7 +238,7 @@ class Observer
             return 'Closure' . self::$filterCount++;
         }
         if (is_object($function)) {
-            $function = array($function, '');
+            $function = [$function, ''];
         } else {
             $function = (array) $function;
         }

--- a/tests/Facebook/InstantArticles/AMP/AMPArticleTest.php
+++ b/tests/Facebook/InstantArticles/AMP/AMPArticleTest.php
@@ -32,14 +32,14 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
     {
         $customProperties = array_merge(
             $this->getWodExpertCustomProperties(),
-            array(
-                'media-sizes' => array(
-                    'http://blog.wod.expert/wp-content/uploads/2017/03/fail1.jpg' => array(
+            [
+                'media-sizes' => [
+                    'http://blog.wod.expert/wp-content/uploads/2017/03/fail1.jpg' => [
                         800,
                         454,
-                    ),
-                ),
-            )
+                    ],
+                ],
+            ]
         );
         $this->runIAtoAMPTest('test1', $customProperties);
     }
@@ -70,34 +70,34 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
 
     private function getWodExpertCustomProperties()
     {
-        return array(
-            AMPArticle::PUBLISHER_KEY => array(
+        return [
+            AMPArticle::PUBLISHER_KEY => [
                 '@type' => 'Organization',
                 'name' => 'WOD Expert',
-                'logo' => array(
+                'logo' => [
                     '@type' => 'ImageObject',
                     'url' => 'http://blog.wod.expert/wp-content/uploads/2017/04/wod-expert-amp-org-logo.png',
                     'width' => 600,
                     'height' => 60,
-                ),
-            )
-        );
+                ],
+            ]
+        ];
     }
 
     public function testTransformIAtoAMPTestTutorial()
     {
-        $this->runIAtoAMPTest('tutorial', array('google_maps_key'=>'123'));
+        $this->runIAtoAMPTest('tutorial', ['google_maps_key'=>'123']);
     }
 
     private function getRenderer($test, $customProperties = null)
     {
         $instantArticle = $this->loadInstantArticle(__DIR__ . '/articles/'.$test.'-instant-article.html');
 
-        $properties = array(
+        $properties = [
             'lang' => 'en-US',
             AMPArticle::STYLES_FOLDER_KEY => __DIR__,
             AMPArticle::ENABLE_DOWNLOAD_FOR_MEDIA_SIZING_KEY => false,
-        );
+        ];
         if (!is_null($customProperties)) {
             $properties = array_merge($properties, $customProperties);
         }
@@ -224,37 +224,37 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
 
     public function testSchemaOrgAuthor()
     {
-        $expectedAuthor = array(
+        $expectedAuthor = [
             '@type' => 'Person',
             'name' => 'Éverton Rosário',
-        );
+        ];
 
         $this->verifySchemaOrgHasExpectedValue('author', $expectedAuthor);
     }
 
     public function testSchemaOrgImageNoCache()
     {
-        $expectedImage = array(
+        $expectedImage = [
             '@type' => 'ImageObject',
             'url' => 'http://blog.wod.expert/wp-content/uploads/2017/03/fail1.jpg',
             'width' => 380,
             'height' => 240,
-        );
+        ];
 
         $this->verifySchemaOrgHasExpectedValue('image', $expectedImage);
     }
 
     public function testSchemaOrgImageWithCache()
     {
-        $expectedImage = array(
+        $expectedImage = [
             '@type' => 'ImageObject',
             'url' => 'http://blog.wod.expert/wp-content/uploads/2017/03/fail1.jpg',
             'width' => 400,
             'height' => 227,
-        );
-        $customProperties = array(
+        ];
+        $customProperties = [
             AMPArticle::MEDIA_CACHE_FOLDER_KEY => __DIR__ . '/articles/media-cache',
-        );
+        ];
 
         $this->verifySchemaOrgHasExpectedValue('image', $expectedImage, 'test1', $customProperties);
     }
@@ -267,23 +267,23 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
     public function testSchemaOrgPublisherName()
     {
         $publisherName = 'The Publisher';
-        $customProperties = array(AMPArticle::PUBLISHER_KEY => $publisherName);
+        $customProperties = [AMPArticle::PUBLISHER_KEY => $publisherName];
 
-        $expectedPublisher = array(
+        $expectedPublisher = [
             '@type' => 'Organization',
             'name' => $publisherName,
-        );
+        ];
 
         $this->verifySchemaOrgHasExpectedValue('publisher', $expectedPublisher, 'test1', $customProperties);
     }
 
     public function testSchemaOrgPublisherArray()
     {
-        $publisher = array(
+        $publisher = [
             '@type' => 'Robot',
             'name' => 'The Robot',
-        );
-        $customProperties = array(AMPArticle::PUBLISHER_KEY => $publisher);
+        ];
+        $customProperties = [AMPArticle::PUBLISHER_KEY => $publisher];
 
         $this->verifySchemaOrgHasExpectedValue('publisher', $publisher, 'test1', $customProperties);
     }
@@ -336,9 +336,9 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
     public function testCachedImageHeight()
     {
         $expectedHeight = 181;
-        $customProperties = array(
+        $customProperties = [
             AMPArticle::MEDIA_CACHE_FOLDER_KEY => __DIR__ . '/articles/media-cache',
-        );
+        ];
 
         $coverImageXPathQuery = $this->getRenderedMarkupXPathQuery(
             'test2',
@@ -353,10 +353,10 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
     public function testImageHeightDownloadDisabled()
     {
         $expectedHeight = 240;
-        $customProperties = array(
+        $customProperties = [
             AMPArticle::MEDIA_CACHE_FOLDER_KEY => __DIR__ . '/articles/media-cache',
             AMPArticle::ENABLE_DOWNLOAD_FOR_MEDIA_SIZING_KEY => false,
-        );
+        ];
 
         $imageXPathQuery = $this->getRenderedMarkupXPathQuery(
             'test1',
@@ -371,10 +371,10 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
     public function testImageHeightDefaultProperty()
     {
         $expectedHeight = 120;
-        $customProperties = array(
+        $customProperties = [
             AMPArticle::ENABLE_DOWNLOAD_FOR_MEDIA_SIZING_KEY => false,
             AMPArticle::DEFAULT_MEDIA_HEIGHT_KEY => $expectedHeight,
-        );
+        ];
 
         $imageXPathQuery = $this->getRenderedMarkupXPathQuery(
             'test1',
@@ -389,12 +389,12 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
     public function testImageHeightFromMediaSizes()
     {
         $expectedHeight = 253;
-        $customProperties = array(
+        $customProperties = [
             AMPArticle::ENABLE_DOWNLOAD_FOR_MEDIA_SIZING_KEY => false,
-            AMPArticle::MEDIA_SIZES_KEY => array(
-                "http://blog.wod.expert/wp-content/uploads/2017/03/fail2.jpg" => array(90, 60),
-            ),
-        );
+            AMPArticle::MEDIA_SIZES_KEY => [
+                "http://blog.wod.expert/wp-content/uploads/2017/03/fail2.jpg" => [90, 60],
+            ],
+        ];
 
         $imageXPathQuery = $this->getRenderedMarkupXPathQuery(
             'test1',
@@ -409,10 +409,10 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
     public function testVideoHeightDefaultProperty()
     {
         $expectedHeight = 120;
-        $customProperties = array(
+        $customProperties = [
             AMPArticle::ENABLE_DOWNLOAD_FOR_MEDIA_SIZING_KEY => false,
             AMPArticle::DEFAULT_MEDIA_HEIGHT_KEY => $expectedHeight,
-        );
+        ];
 
         $videoXPathQuery = $this->getRenderedMarkupXPathQuery(
             'tutorial',
@@ -480,14 +480,14 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
         $coverImageXPathQuery = $this->getRenderedMarkupXPathQuery(
             'test1',
             '//amp-img[@class=\'ia2amp-header-cover-img\']',
-            array(
-                'media-sizes' => array(
-                    'http://blog.wod.expert/wp-content/uploads/2017/03/fail1.jpg' => array(
+            [
+                'media-sizes' => [
+                    'http://blog.wod.expert/wp-content/uploads/2017/03/fail1.jpg' => [
                         800,
                         454,
-                    ),
-                ),
-            )
+                    ],
+                ],
+            ]
         );
 
         $coverImageElement = $coverImageXPathQuery->item(0);
@@ -501,14 +501,14 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
         $coverImageXPathQuery = $this->getRenderedMarkupXPathQuery(
             'test1',
             '//amp-img[@class=\'ia2amp-header-cover-img\']',
-            array(
-                'media-sizes' => array(
-                    'http://blog.wod.expert/wp-content/uploads/2017/03/fail1.jpg' => array(
+            [
+                'media-sizes' => [
+                    'http://blog.wod.expert/wp-content/uploads/2017/03/fail1.jpg' => [
                         800,
                         454,
-                    ),
-                ),
-            )
+                    ],
+                ],
+            ]
         );
 
         $coverImageElement = $coverImageXPathQuery->item(0);
@@ -527,14 +527,14 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
 
     public function testToRGBDataProvider()
     {
-        return array(
-            array('FFAABB', 'rgb(255,170,187)'),
-            array('#FFAABB', 'rgb(255,170,187)'),
-            array('#FFFFAABB', 'rgb(255,170,187)'),
-            array('EEFFAABB', 'rgba(255,170,187,0.93)'),
-            array('#EEFFAABB', 'rgba(255,170,187,0.93)'),
-            array('#00FFFFFF', 'rgba(255,255,255,0)'),
-        );
+        return [
+            ['FFAABB', 'rgb(255,170,187)'],
+            ['#FFAABB', 'rgb(255,170,187)'],
+            ['#FFFFAABB', 'rgb(255,170,187)'],
+            ['EEFFAABB', 'rgba(255,170,187,0.93)'],
+            ['#EEFFAABB', 'rgba(255,170,187,0.93)'],
+            ['#00FFFFFF', 'rgba(255,255,255,0)'],
+        ];
     }
 
     private function getDefaultStyles()
@@ -550,9 +550,9 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
         $defaultStyles = $this->getDefaultStyles();
         $defaultStyles['background_color'] = $hexColor;
 
-        $customProperties = array(
+        $customProperties = [
             AMPArticle::OVERRIDE_STYLES_KEY => $defaultStyles,
-        );
+        ];
 
         $renderer = $this->getRenderer('test1', $customProperties);
         $context = AMPContext::create(new \DOMDocument(), $renderer->getInstantArticle(), 'ia2amp-');
@@ -608,7 +608,7 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
      */
     private function getTextStylesTestData($styleName, $cssSelector)
     {
-        $testData = array();
+        $testData = [];
 
         // Font Family
         $testData = array_merge(
@@ -750,22 +750,22 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
         $cssProperty
     ) {
 
-        $testData = array();
+        $testData = [];
 
         // Get all test cases for the given Data Provider function
-        $dataProviderTestData = call_user_func_array(array($this, $dataProviderFunctionName), array());
+        $dataProviderTestData = call_user_func_array([$this, $dataProviderFunctionName], []);
 
         foreach ($dataProviderTestData as $dataProviderTestItem) {
             // Call the Validation Arguments Provider function using the values from the Data Provider
-            $styleAndCssValues = call_user_func_array(array($this, $validationArgumentsProviderFunctionName), $dataProviderTestItem);
+            $styleAndCssValues = call_user_func_array([$this, $validationArgumentsProviderFunctionName], $dataProviderTestItem);
             // Merge the known values with the mappings of style value to expected CSS value
             $testDataItem = array_merge(
-                array(
+                [
                     $styleName,
                     $secondLevelProperty,
                     $cssSelector,
                     $cssProperty,
-                ),
+                ],
                 $styleAndCssValues
             );
             // Add the merged values to the list of test items
@@ -784,7 +784,7 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
      */
     private function passThroughValuesProvider($stylePropertyName, $expectedCSSValue)
     {
-        return array($stylePropertyName, $expectedCSSValue);
+        return [$stylePropertyName, $expectedCSSValue];
     }
 
     /**
@@ -795,9 +795,9 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
     private function randomDataProvider()
     {
         $randomValue = rand();
-        return array(
-            array($randomValue, $randomValue),
-        );
+        return [
+            [$randomValue, $randomValue],
+        ];
     }
 
     /**
@@ -810,9 +810,9 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
         $hexColor = AMPArticleTest::getRandomHexColor();
         // Escape parenthesis before using regex
         $expectedValue = str_replace(')', '\)', str_replace('(', '\(', AMPArticle::toRGB($hexColor)));
-        return array(
-            array($hexColor, $expectedValue),
-        );
+        return [
+            [$hexColor, $expectedValue],
+        ];
     }
 
     /**
@@ -822,11 +822,11 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
      */
     private function textTransformDataProvider()
     {
-        return array(
-            array('ALL_CAPS', 'uppercase'),
-            array('NONE', 'none'),
-            array('ALL_LOWER_CASE', 'lowercase'),
-        );
+        return [
+            ['ALL_CAPS', 'uppercase'],
+            ['NONE', 'none'],
+            ['ALL_LOWER_CASE', 'lowercase'],
+        ];
     }
 
     /**
@@ -836,11 +836,11 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
      */
     public function textAlignmentDataProvider()
     {
-        return array(
-            array('LEFT', 'LEFT'),
-            array('CENTER', 'CENTER'),
-            array('RIGHT', 'RIGHT'),
-        );
+        return [
+            ['LEFT', 'LEFT'],
+            ['CENTER', 'CENTER'],
+            ['RIGHT', 'RIGHT'],
+        ];
     }
 
     /**
@@ -850,10 +850,10 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
      */
     public function displayDataProvider()
     {
-        return array(
-            array('INLINE', 'INLINE'),
-            array('BLOCK', 'BLOCK'),
-        );
+        return [
+            ['INLINE', 'INLINE'],
+            ['BLOCK', 'BLOCK'],
+        ];
     }
 
     /**
@@ -868,18 +868,18 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
     public function spacingValuesProvider($size, $baseSpacingValue, $direction, $spacingFormat)
     {
         $scalingFactor = rand(0, 1000) / 1000 + 0.5;
-        $directionSpacing = array(
+        $directionSpacing = [
             'scaling_factor' => $scalingFactor,
             'size' => $size,
-        );
-        $spacingStyle = array(
+        ];
+        $spacingStyle = [
             $direction => $directionSpacing,
-        );
+        ];
 
         $expectedSpacing = $baseSpacingValue * $scalingFactor;
         $expectedValue  = sprintf($spacingFormat, $expectedSpacing);
 
-        return array($spacingStyle, $expectedValue);
+        return [$spacingStyle, $expectedValue];
     }
 
     /**
@@ -889,14 +889,14 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
      */
     private function marginDataProvider()
     {
-        return array(
+        return [
             // size, baseSpacingValue, direction, spacingFormat
-            array('DOCUMENT_MARGIN', AMPArticle::DEFAULT_MARGIN, 'right', '0 %spx 0 0'),
-            array('DOCUMENT_MARGIN', AMPArticle::DEFAULT_MARGIN, 'left', '0 0 0 %spx'),
+            ['DOCUMENT_MARGIN', AMPArticle::DEFAULT_MARGIN, 'right', '0 %spx 0 0'],
+            ['DOCUMENT_MARGIN', AMPArticle::DEFAULT_MARGIN, 'left', '0 0 0 %spx'],
 
-            array('NONE', 0, 'right', '0 0 0 0'),
-            array('NONE', 0, 'left', '0 0 0 0'),
-        );
+            ['NONE', 0, 'right', '0 0 0 0'],
+            ['NONE', 0, 'left', '0 0 0 0'],
+        ];
     }
 
     /**
@@ -906,18 +906,18 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
      */
     private function paddingDataProvider()
     {
-        return array(
+        return [
             // size, baseSpacingValue, direction, spacingFormat
-            array('NONE', 0, 'top', '0 0 0 0'),
-            array('NONE', 0, 'right', '0 0 0 0'),
-            array('NONE', 0, 'bottom', '0 0 0 0'),
-            array('NONE', 0, 'left', '0 0 0 0'),
+            ['NONE', 0, 'top', '0 0 0 0'],
+            ['NONE', 0, 'right', '0 0 0 0'],
+            ['NONE', 0, 'bottom', '0 0 0 0'],
+            ['NONE', 0, 'left', '0 0 0 0'],
 
-            array('MEDIUM', 46, 'top', '%spx 0 0 0'),
-            array('MEDIUM', 46, 'right', '0 %spx 0 0'),
-            array('MEDIUM', 46, 'bottom', '0 0 %spx 0'),
-            array('MEDIUM', 46, 'left', '0 0 0 %spx'),
-        );
+            ['MEDIUM', 46, 'top', '%spx 0 0 0'],
+            ['MEDIUM', 46, 'right', '0 %spx 0 0'],
+            ['MEDIUM', 46, 'bottom', '0 0 %spx 0'],
+            ['MEDIUM', 46, 'left', '0 0 0 %spx'],
+        ];
     }
 
     /**
@@ -930,18 +930,18 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
     {
         $width = rand(0, 100);
         $hexColor = AMPArticleTest::getRandomHexColor();
-        $directionBorder = array(
+        $directionBorder = [
             'color' => $hexColor,
             'width' => $width,
-        );
-        $borderStyle = array(
+        ];
+        $borderStyle = [
             $direction => $directionBorder,
-        );
+        ];
 
         // Escape parenthesis before using regex
         $expectedValue = str_replace(')', '\)', str_replace('(', '\(', AMPArticle::toRGB($hexColor)));
 
-        return array($borderStyle, $expectedValue);
+        return [$borderStyle, $expectedValue];
     }
 
     /**
@@ -951,12 +951,12 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
      */
     private function directionsDataProvider()
     {
-        return array(
-            array('top'),
-            array('right'),
-            array('bottom'),
-            array('left'),
-        );
+        return [
+            ['top'],
+            ['right'],
+            ['bottom'],
+            ['left'],
+        ];
     }
 
     /**
@@ -969,16 +969,16 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
     public function borderWidthValuesProvider($direction, $borderFormat)
     {
         $width = rand(0, 100);
-        $directionBorder = array(
+        $directionBorder = [
             'color' => '#000000',
             'width' => $width,
-        );
-        $borderStyle = array(
+        ];
+        $borderStyle = [
             $direction => $directionBorder,
-        );
+        ];
 
         $expectedValue  = sprintf($borderFormat, $width !== 0 ? $width . 'px' : 0);
-        return array($borderStyle, $expectedValue);
+        return [$borderStyle, $expectedValue];
     }
 
     /**
@@ -988,12 +988,12 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
      */
     private function borderWidthDataProvider()
     {
-        return array(
-            array('top', '%s 0 0 0'),
-            array('right', '0 %s 0 0'),
-            array('bottom', '0 0 %s 0'),
-            array('left', '0 0 0 %s'),
-        );
+        return [
+            ['top', '%s 0 0 0'],
+            ['right', '0 %s 0 0'],
+            ['bottom', '0 0 %s 0'],
+            ['left', '0 0 0 %s'],
+        ];
     }
 
     /**
@@ -1014,10 +1014,10 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
         // Set the style property value that will be used to generate the expected CSS
         $testStyles[$firstLevelKey][$secondLevelKey] = $styleValue;
 
-        $customProperties = array(
+        $customProperties = [
             // Use the updated styles instead of the ones defined in the Instant Article document
             AMPArticle::OVERRIDE_STYLES_KEY => $testStyles,
-        );
+        ];
 
         $renderer = $this->getRenderer('test1', $customProperties);
         $context = AMPContext::create(new \DOMDocument(), $renderer->getInstantArticle(), 'ia2amp-');
@@ -1063,7 +1063,7 @@ class AMPArticleTest extends FileUtilsPHPUnitTestCase
 
     public function testBuildAnalytics()
     {
-        $properties = array();
+        $properties = [];
         $properties['analytics'] = [
             '<amp-pixel src="https://foo.com/pixel?RANDOM"></amp-pixel>',
             '<amp-analytics><script type="application/json">{}</script></amp-analytics>'

--- a/tests/Facebook/InstantArticles/AMP/AMPCaptionTest.php
+++ b/tests/Facebook/InstantArticles/AMP/AMPCaptionTest.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\AMP;
 
-
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Header;
 use Facebook\InstantArticles\Elements\Image;

--- a/tests/Facebook/InstantArticles/AMP/AMPCaptionTest.php
+++ b/tests/Facebook/InstantArticles/AMP/AMPCaptionTest.php
@@ -82,7 +82,7 @@ class AMPCaptionTest extends Framework\TestCase
     {
         $context = AMPContext::create($document, $instantArticle);
 
-        $mediaSizes = array();
+        $mediaSizes = [];
         $mediaCacheFolder = __DIR__ . '/articles/media-cache';
         $enableDownloadForMediaSizing = false;
         $defaultWidth = 1000;

--- a/tests/Facebook/InstantArticles/AMP/AMPContextTest.php
+++ b/tests/Facebook/InstantArticles/AMP/AMPContextTest.php
@@ -12,8 +12,6 @@ use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Paragraph;
 use PHPUnit\Framework;
 
-
-
 class AMPContextTest extends Framework\TestCase
 {
     protected function setUp()

--- a/tests/Facebook/InstantArticles/AMP/AMPContextTest.php
+++ b/tests/Facebook/InstantArticles/AMP/AMPContextTest.php
@@ -313,7 +313,7 @@ class AMPContextTest extends Framework\TestCase
         $document = new \DOMDocument();
         $context = AMPContext::create($document, InstantArticle::create());
 
-        $mediaSizes = array('https://www.facebook.com/images/fb_icon_325x325.png' => array($expectedWidth, $expectedHeight));
+        $mediaSizes = ['https://www.facebook.com/images/fb_icon_325x325.png' => [$expectedWidth, $expectedHeight]];
         $mediaCacheFolder = __DIR__ . '/articles/media-cache';
         $enableDownloadForMediaSizing = true;
         $defaultWidth = 1000;
@@ -334,7 +334,7 @@ class AMPContextTest extends Framework\TestCase
         $document = new \DOMDocument();
         $context = AMPContext::create($document, InstantArticle::create());
 
-        $mediaSizes = array();
+        $mediaSizes = [];
         $mediaCacheFolder = __DIR__ . '/articles/media-cache';
         $enableDownloadForMediaSizing = true;
         $defaultWidth = 1000;
@@ -355,7 +355,7 @@ class AMPContextTest extends Framework\TestCase
         $document = new \DOMDocument();
         $context = AMPContext::create($document, InstantArticle::create());
 
-        $mediaSizes = array();
+        $mediaSizes = [];
         $mediaCacheFolder = __DIR__ . '/articles/media-cache';
         $enableDownloadForMediaSizing = false;
         $defaultWidth = 1000;
@@ -376,7 +376,7 @@ class AMPContextTest extends Framework\TestCase
         $document = new \DOMDocument();
         $context = AMPContext::create($document, InstantArticle::create());
 
-        $mediaSizes = array();
+        $mediaSizes = [];
         $mediaCacheFolder = null;
         $enableDownloadForMediaSizing = true;
         $defaultWidth = 1000;
@@ -394,7 +394,7 @@ class AMPContextTest extends Framework\TestCase
         $document = new \DOMDocument();
         $context = AMPContext::create($document, InstantArticle::create());
 
-        $mediaSizes = array();
+        $mediaSizes = [];
         $mediaCacheFolder = null;
         $enableDownloadForMediaSizing = false;
         $defaultWidth = 1000;
@@ -415,7 +415,7 @@ class AMPContextTest extends Framework\TestCase
         $document = new \DOMDocument();
         $context = AMPContext::create($document, InstantArticle::create());
 
-        $mediaSizes = array('http://ngm.nationalgeographic.com/2015/05/building-bees/v/timelapse-final-4x3.mp4' => array($expectedWidth, $expectedHeight));
+        $mediaSizes = ['http://ngm.nationalgeographic.com/2015/05/building-bees/v/timelapse-final-4x3.mp4' => [$expectedWidth, $expectedHeight]];
         $mediaCacheFolder = __DIR__ . '/articles/media-cache';
         $enableDownloadForMediaSizing = true;
         $defaultWidth = 1000;
@@ -433,7 +433,7 @@ class AMPContextTest extends Framework\TestCase
         $document = new \DOMDocument();
         $context = AMPContext::create($document, InstantArticle::create());
 
-        $mediaSizes = array();
+        $mediaSizes = [];
         $mediaCacheFolder = __DIR__ . '/articles/media-cache';
         $enableDownloadForMediaSizing = true;
         $defaultWidth = 1000;
@@ -451,7 +451,7 @@ class AMPContextTest extends Framework\TestCase
         $document = new \DOMDocument();
         $context = AMPContext::create($document, InstantArticle::create());
 
-        $mediaSizes = array();
+        $mediaSizes = [];
         $mediaCacheFolder = __DIR__ . '/articles/media-cache';
         $enableDownloadForMediaSizing = false;
         $defaultWidth = 1000;
@@ -469,7 +469,7 @@ class AMPContextTest extends Framework\TestCase
         $document = new \DOMDocument();
         $context = AMPContext::create($document, InstantArticle::create());
 
-        $mediaSizes = array();
+        $mediaSizes = [];
         $mediaCacheFolder = null;
         $enableDownloadForMediaSizing = true;
         $defaultWidth = 1000;
@@ -487,7 +487,7 @@ class AMPContextTest extends Framework\TestCase
         $document = new \DOMDocument();
         $context = AMPContext::create($document, InstantArticle::create());
 
-        $mediaSizes = array();
+        $mediaSizes = [];
         $mediaCacheFolder = null;
         $enableDownloadForMediaSizing = false;
         $defaultWidth = 1000;

--- a/tests/Facebook/InstantArticles/AMP/AMPCoverImageTest.php
+++ b/tests/Facebook/InstantArticles/AMP/AMPCoverImageTest.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\AMP;
 
-
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Header;
 use Facebook\InstantArticles\Elements\Image;

--- a/tests/Facebook/InstantArticles/AMP/AMPCoverImageTest.php
+++ b/tests/Facebook/InstantArticles/AMP/AMPCoverImageTest.php
@@ -78,7 +78,7 @@ class AMPCoverImageTest extends Framework\TestCase
     {
         $context = AMPContext::create($document, $instantArticle);
 
-        $mediaSizes = array();
+        $mediaSizes = [];
         $mediaCacheFolder = __DIR__ . '/articles/media-cache';
         $enableDownloadForMediaSizing = false;
         $defaultWidth = 1000;

--- a/tests/Facebook/InstantArticles/AMP/AMPHeaderTest.php
+++ b/tests/Facebook/InstantArticles/AMP/AMPHeaderTest.php
@@ -26,11 +26,11 @@ class AMPHeaderTest extends FileUtilsPHPUnitTestCase
     private function getRenderer($test, $customProperties = null)
     {
         $instantArticle = $this->loadInstantArticle(__DIR__ . '/articles/'.$test.'-instant-article.html');
-        $properties = array(
+        $properties = [
             'lang' => 'en-US',
             AMPArticle::STYLES_FOLDER_KEY => __DIR__,
             AMPArticle::ENABLE_DOWNLOAD_FOR_MEDIA_SIZING_KEY => false,
-        );
+        ];
         if (!is_null($customProperties)) {
             $properties = array_merge($properties, $customProperties);
         }
@@ -43,7 +43,7 @@ class AMPHeaderTest extends FileUtilsPHPUnitTestCase
         $renderer = $this->getRenderer('test1', null);
         $context = AMPContext::create(new \DOMDocument('1.0'), $renderer->getInstantArticle());
 
-        $mediaSizes = array();
+        $mediaSizes = [];
         $mediaCacheFolder = __DIR__ . '/articles/media-cache';
         $enableDownloadForMediaSizing = false;
         $defaultWidth = 1000;
@@ -91,14 +91,14 @@ class AMPHeaderTest extends FileUtilsPHPUnitTestCase
         //$this->assertEquals("May 10, 2016", $publicationDate);
         $this->assertEquals("By Éverton Rosário", $byLine);
 
-        $spaceNodes = array(
+        $spaceNodes = [
         '//div[@class="ia2amp-header-bar"][1]',
         '//h2[@class="ia2amp-spacing after-header-date"][1]',
         '//h2[@class="ia2amp-spacing after-header-author before-header-date"][1]',
         '//div[@class="ia2amp-spacing after-header-category before-header-h1"][1]',
         '//div[@class="ia2amp-spacing after-header-h1 before-header-author"]',
         '//div[@class="ia2amp-spacing after-header-bar before-header-category"]',
-        );
+        ];
 
         foreach ($spaceNodes as $currentNode) {
               $this->assertNotEmpty($testingHeader->query($currentNode));

--- a/tests/Facebook/InstantArticles/Utils/CSSBuilderTest.php
+++ b/tests/Facebook/InstantArticles/Utils/CSSBuilderTest.php
@@ -181,8 +181,8 @@ class CSSBuilderTest extends Framework\TestCase
         $expected = $this->genArrayCSSFormatted('myprefix-');
 
         $cssBuilder = new CSSBuilder('myprefix-');
-        $cssBuilder->addToSelector(array('someClass1', 'someClass2'), 'width', '300px')
-                   ->addToSelector(array('someClass1', 'someClass2'), 'height', '400px')
+        $cssBuilder->addToSelector(['someClass1', 'someClass2'], 'width', '300px')
+                   ->addToSelector(['someClass1', 'someClass2'], 'height', '400px')
                    ->addToSelector('someClass1', 'color', '#fff');
         $result = $cssBuilder->build(true);
         $this->assertEquals($expected, $result);

--- a/tests/Facebook/InstantArticles/Utils/Greeting.php
+++ b/tests/Facebook/InstantArticles/Utils/Greeting.php
@@ -8,7 +8,6 @@
  */
 namespace Facebook\InstantArticles\Utils;
 
-
 /*
  * Sample class used for testing the Observer.
  */

--- a/tests/Facebook/InstantArticles/Utils/HookTest.php
+++ b/tests/Facebook/InstantArticles/Utils/HookTest.php
@@ -76,38 +76,38 @@ class HookTest extends Framework\TestCase
     public function testHookDefault()
     {
         $hook = Hook::create();
-        $result = $hook->call('hook_name', array($this, 'methodHook'));
+        $result = $hook->call('hook_name', [$this, 'methodHook']);
         $this->assertEquals('result', $result);
     }
 
     public function testHookReplacingDefault()
     {
         $hook = Hook::create();
-        $hook->setHook('hook_name', array($this, 'methodHookReplacing'));
-        $result = $hook->call('hook_name', array($this, 'methodHook'));
+        $hook->setHook('hook_name', [$this, 'methodHookReplacing']);
+        $result = $hook->call('hook_name', [$this, 'methodHook']);
         $this->assertEquals('REPLACED', $result);
     }
 
     public function testHookReplacingDefaultRemoved()
     {
         $hook = Hook::create();
-        $hook->setHook('hook_name', array($this, 'methodHookReplacing'));
-        $result = $hook->call('hook_name', array($this, 'methodHook'));
+        $hook->setHook('hook_name', [$this, 'methodHookReplacing']);
+        $result = $hook->call('hook_name', [$this, 'methodHook']);
         $this->assertEquals('REPLACED', $result);
 
         $hook->removeHook('hook_name');
-        $result = $hook->call('hook_name', array($this, 'methodHook'));
+        $result = $hook->call('hook_name', [$this, 'methodHook']);
         $this->assertEquals('result', $result);
     }
 
     public function testHookRemovingSomethingNeverAdded()
     {
         $hook = Hook::create();
-        $result = $hook->call('hook_name', array($this, 'methodHook'));
+        $result = $hook->call('hook_name', [$this, 'methodHook']);
         $this->assertEquals('result', $result);
 
         $hook->removeHook('hook_name');
-        $result = $hook->call('hook_name', array($this, 'methodHook'));
+        $result = $hook->call('hook_name', [$this, 'methodHook']);
         $this->assertEquals('result', $result);
     }
 
@@ -121,14 +121,14 @@ class HookTest extends Framework\TestCase
         // Calls method without overriding the value, so the return should be 1
         $objToChange->first = '1';
         $objToChange->second = '2';
-        $result = $hook->call('hook_name', array($this, 'methodHookTestingBefore'), array($objToChange));
+        $result = $hook->call('hook_name', [$this, 'methodHookTestingBefore'], [$objToChange]);
         $this->assertEquals('MAIN-WITH-BEFORE-1-2', $result);
 
         // Calls method overriding the value, so the return should be 1st
         $objToChange->first = '1';
         $objToChange->second = '2';
-        $hook->setBeforeHook('hook_name', array($this, 'methodHookBefore1'), array($objToChange));
-        $result = $hook->call('hook_name', array($this, 'methodHookTestingBefore'), array($objToChange));
+        $hook->setBeforeHook('hook_name', [$this, 'methodHookBefore1'], [$objToChange]);
+        $result = $hook->call('hook_name', [$this, 'methodHookTestingBefore'], [$objToChange]);
         $this->assertEquals('MAIN-WITH-BEFORE-1st-2', $result);
     }
 
@@ -142,14 +142,14 @@ class HookTest extends Framework\TestCase
         // Calls method without overriding the value, so the return should be 1
         $objToChange->first = '1';
         $objToChange->second = '2';
-        $result = $hook->call('hook_name', array($this, 'methodHookTestingAfter'), array($objToChange));
+        $result = $hook->call('hook_name', [$this, 'methodHookTestingAfter'], [$objToChange]);
         $this->assertEquals('MAIN-WITH-AFTER-1-2', $result);
 
         // Calls method overriding the value, so the return should be 2nd
         $objToChange->first = '1';
         $objToChange->second = '2';
-        $hook->setAfterHook('hook_name', array($this, 'methodHookAfter2'), array($objToChange));
-        $result = $hook->call('hook_name', array($this, 'methodHookTestingAfter'), array($objToChange));
+        $hook->setAfterHook('hook_name', [$this, 'methodHookAfter2'], [$objToChange]);
+        $result = $hook->call('hook_name', [$this, 'methodHookTestingAfter'], [$objToChange]);
         $this->assertEquals('MAIN-WITH-AFTER-1-2', $result);
         $this->assertEquals('2nd', $objToChange->second);
     }
@@ -164,21 +164,21 @@ class HookTest extends Framework\TestCase
         // Calls method without overriding the value, so the return should be 1
         $objToChange->first = '1';
         $objToChange->second = '2';
-        $result = $hook->call('hook_name', array($this, 'methodHookTestingBefore'), array($objToChange));
+        $result = $hook->call('hook_name', [$this, 'methodHookTestingBefore'], [$objToChange]);
         $this->assertEquals('MAIN-WITH-BEFORE-1-2', $result);
 
         // Calls method overriding the value, so the return should be 1st
         $objToChange->first = '1';
         $objToChange->second = '2';
-        $hook->setBeforeHook('hook_name', array($this, 'methodHookBefore1'), array($objToChange));
-        $result = $hook->call('hook_name', array($this, 'methodHookTestingBefore'), array($objToChange));
+        $hook->setBeforeHook('hook_name', [$this, 'methodHookBefore1'], [$objToChange]);
+        $result = $hook->call('hook_name', [$this, 'methodHookTestingBefore'], [$objToChange]);
         $this->assertEquals('MAIN-WITH-BEFORE-1st-2', $result);
 
         // Calls method overriding the value, so the return should be 2nd
         $objToChange->first = '1';
         $objToChange->second = '2';
-        $hook->setAfterHook('hook_name', array($this, 'methodHookAfter2'), array($objToChange));
-        $result = $hook->call('hook_name', array($this, 'methodHookTestingAfter'), array($objToChange));
+        $hook->setAfterHook('hook_name', [$this, 'methodHookAfter2'], [$objToChange]);
+        $result = $hook->call('hook_name', [$this, 'methodHookTestingAfter'], [$objToChange]);
         $this->assertEquals('MAIN-WITH-AFTER-1st-2', $result);
         $this->assertEquals('2nd', $objToChange->second);
     }
@@ -191,38 +191,38 @@ class HookTest extends Framework\TestCase
         // Calls method without overriding the value, so the return should be 1
         $objToChange->first = '1';
         $objToChange->second = '2';
-        $hook->setBeforeHook('hook_name', array($this, 'methodHookBefore1'), array($objToChange));
-        $hook->setAfterHook('hook_name', array($this, 'methodHookAfter2'), array($objToChange));
-        $result = $hook->call('hook_name', array($this, 'methodHookTestingAfter'), array($objToChange));
+        $hook->setBeforeHook('hook_name', [$this, 'methodHookBefore1'], [$objToChange]);
+        $hook->setAfterHook('hook_name', [$this, 'methodHookAfter2'], [$objToChange]);
+        $result = $hook->call('hook_name', [$this, 'methodHookTestingAfter'], [$objToChange]);
         $this->assertEquals('MAIN-WITH-AFTER-1st-2', $result);
         $this->assertEquals('2nd', $objToChange->second);
 
         $objToChange->first = '1';
         $objToChange->second = '2';
         $hook->clearHooks('hook_name');
-        $result = $hook->call('hook_name', array($this, 'methodHookTestingBefore'), array($objToChange));
+        $result = $hook->call('hook_name', [$this, 'methodHookTestingBefore'], [$objToChange]);
         $this->assertEquals('MAIN-WITH-BEFORE-1-2', $result);
     }
 
     public function testHookReplacingDefaultParams()
     {
         $hook = Hook::create();
-        $hook->setHook('hook_name', array($this, 'methodHookReplacing'), array('param1', 'param2'));
-        $result = $hook->call('hook_name', array($this, 'methodHook'));
+        $hook->setHook('hook_name', [$this, 'methodHookReplacing'], ['param1', 'param2']);
+        $result = $hook->call('hook_name', [$this, 'methodHook']);
         $this->assertEquals('REPLACED-param1-param2', $result);
     }
 
     public function testHookStaticMethod()
     {
         $hook = Hook::create();
-        $result = $hook->call('hook_name', array('Facebook\InstantArticles\Utils\HookTest', 'staticMethodHook'));
+        $result = $hook->call('hook_name', ['Facebook\InstantArticles\Utils\HookTest', 'staticMethodHook']);
         $this->assertEquals('STATIC', $result);
     }
 
     public function testHookStaticMethodParams()
     {
         $hook = Hook::create();
-        $result = $hook->call('hook_name', array('Facebook\InstantArticles\Utils\HookTest', 'staticMethodHookParams'), array('param1', 'param2'));
+        $result = $hook->call('hook_name', ['Facebook\InstantArticles\Utils\HookTest', 'staticMethodHookParams'], ['param1', 'param2']);
         $this->assertEquals('STATIC-with-params-param1-param2', $result);
     }
 
@@ -236,7 +236,7 @@ class HookTest extends Framework\TestCase
     public function testHookFunctionNoClassWithParam()
     {
         $hook = Hook::create();
-        $result = $hook->call('hook_name', 'Facebook\InstantArticles\Utils\functionOutsideClassWithParams', array('param1'));
+        $result = $hook->call('hook_name', 'Facebook\InstantArticles\Utils\functionOutsideClassWithParams', ['param1']);
         $this->assertEquals('OUTSIDER-with-param-param1', $result);
     }
 }

--- a/tests/Facebook/InstantArticles/Utils/ObserverTest.php
+++ b/tests/Facebook/InstantArticles/Utils/ObserverTest.php
@@ -52,7 +52,7 @@ class ObserverTest extends Framework\TestCase
     public function testStaticFilter()
     {
         $observer = Observer::create();
-        $observer->addFilter('name', array("Facebook\InstantArticles\Utils\Greeting", "hello"));
+        $observer->addFilter('name', ["Facebook\InstantArticles\Utils\Greeting", "hello"]);
 
         $name = $observer->applyFilters('name', "Bob");
         $this->assertEquals('Hello Bob', $name);
@@ -64,8 +64,8 @@ class ObserverTest extends Framework\TestCase
         $hello = new Greeting("Hello");
 
         $observer = Observer::create();
-        $observer->addFilter('name', array(&$mr, "greet"));
-        $observer->addFilter('name', array(&$hello, "greet"));
+        $observer->addFilter('name', [&$mr, "greet"]);
+        $observer->addFilter('name', [&$hello, "greet"]);
 
         $name = $observer->applyFilters('name', "Bob");
         $this->assertEquals('Hello Mr. Bob', $name);
@@ -76,7 +76,7 @@ class ObserverTest extends Framework\TestCase
         $hello = new Greeting("Hello");
 
         $observer = Observer::create();
-        $observer->addFilter('name', array(&$hello, "greet"), 10, 4);
+        $observer->addFilter('name', [&$hello, "greet"], 10, 4);
 
         $name = $observer->applyFilters('name', "Spongebob", "Square", "Pants");
         $this->assertEquals('Hello Spongebob Square Pants', $name);
@@ -88,8 +88,8 @@ class ObserverTest extends Framework\TestCase
         $mr = new Greeting("Mr.");
 
         $observer = Observer::create();
-        $observer->addFilter('name', array(&$hello, "greet"), 11, 2);
-        $observer->addFilter('name', array(&$mr, "greet"), 10, 1);
+        $observer->addFilter('name', [&$hello, "greet"], 11, 2);
+        $observer->addFilter('name', [&$mr, "greet"], 10, 1);
 
         $name = $observer->applyFilters('name', "Bob", "Bobby");
         $this->assertEquals('Hello Mr. Bob Bobby', $name);
@@ -101,13 +101,13 @@ class ObserverTest extends Framework\TestCase
         $mr = new Greeting("Mr.");
 
         $observer = Observer::create();
-        $observer->addFilter('name', array(&$hello, "greet"), 11, 2);
-        $observer->addFilter('name', array(&$mr, "greet"), 10, 1);
+        $observer->addFilter('name', [&$hello, "greet"], 11, 2);
+        $observer->addFilter('name', [&$mr, "greet"], 10, 1);
 
         $name = $observer->applyFilters('name', "Bob", "Bobby");
         $this->assertEquals('Hello Mr. Bob Bobby', $name);
 
-        $observer->removeFilter('name', array(&$mr, "greet"), 10);
+        $observer->removeFilter('name', [&$mr, "greet"], 10);
 
         $name = $observer->applyFilters('name', "Bob", "Bobby");
         $this->assertEquals('Hello Bob Bobby', $name);
@@ -119,8 +119,8 @@ class ObserverTest extends Framework\TestCase
         $mr = new Greeting("Mr.");
 
         $observer = Observer::create();
-        $observer->addFilter('name', array(&$hello, "greet"), 11, 2);
-        $observer->addFilter('name', array(&$mr, "greet"), 10, 1);
+        $observer->addFilter('name', [&$hello, "greet"], 11, 2);
+        $observer->addFilter('name', [&$mr, "greet"], 10, 1);
 
         $name = $observer->applyFilters('name', "Bob", "Bobby");
         $this->assertEquals('Hello Mr. Bob Bobby', $name);
@@ -143,12 +143,12 @@ class ObserverTest extends Framework\TestCase
         $mrs = new Greeting("Mrs.");
 
         $observer = Observer::create();
-        $observer->addFilter('name', array(&$hello, "greet"), 11, 2);
-        $observer->addFilter('name', array(&$mr, "greet"), 10, 1);
+        $observer->addFilter('name', [&$hello, "greet"], 11, 2);
+        $observer->addFilter('name', [&$mr, "greet"], 10, 1);
 
-        $this->assertEquals(11, $observer->hasFilter('name', array(&$hello, "greet")));
-        $this->assertEquals(10, $observer->hasFilter('name', array(&$mr, "greet")));
-        $this->assertFalse($observer->hasFilter('name', array(&$mrs, "greet")));
+        $this->assertEquals(11, $observer->hasFilter('name', [&$hello, "greet"]));
+        $this->assertEquals(10, $observer->hasFilter('name', [&$mr, "greet"]));
+        $this->assertFalse($observer->hasFilter('name', [&$mrs, "greet"]));
         $this->assertTrue($observer->hasFilter('name'));
     }
 }

--- a/tests/Facebook/InstantArticles/Utils/ObserverTest.php
+++ b/tests/Facebook/InstantArticles/Utils/ObserverTest.php
@@ -44,7 +44,6 @@ class ObserverTest extends Framework\TestCase
         $observer = Observer::create();
         $observer->addFilter('name', function ($name) {
             return "$name-san";
-
         });
         $name = $observer->applyFilters('name', "Bob");
         $this->assertEquals('Bob-san', $name);


### PR DESCRIPTION
❗️ Blocked by #10.

This PR

* [x] configures `phpcs` to disallow long array syntax
* [x] runs `composer cs`

💁‍♂️ Since the minimum requirement is PHP 5.4, we can safely use the features provided there, can't we?