### PR TITLE
Fix: Configure GITHUB_TOKEN only when it is available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
   - travis_retry composer self-update
   - composer validate
-  - composer config github-oauth.github.com $GITHUB_TOKEN
+  - if [[ -n "$GITHUB_TOKEN" ]]; then composer config github-oauth.github.com $GITHUB_TOKEN; fi
 
 install:
   - travis_retry composer install --no-interaction --prefer-dist


### PR DESCRIPTION
This PR

* [x] configures the `GITHUB_TOKEN` only when it is available

Blocks #11, #16, #17, #24 insofar as the builds for these are failing. 

💁‍♂️ For reference, see https://docs.travis-ci.com/user/pull-requests#Pull-Requests-and-Security-Restrictions.