### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,9 @@ We want to make contributing to this project as easy and transparent as possible
 
 We accept contributions via pull requests on [GitHub](https://github.com/facebook/facebook-instant-articles-sdk-extensions-in-php).
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+
 ## Pull Requests
 - **Sign the CLA** - In order to accept your pull request, we need you to submit a [Contributor License Agreement](https://code.facebook.com/cla). You only need to do this once to work on any of Facebook's open source projects.
 


### PR DESCRIPTION
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. Let's fix it. :)

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve [the Facebook-instant-articles-sdk-extensions-in-php community profile](https://github.com/facebook/facebook-instant-articles-sdk-extensions-in-php/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1306" alt="screen shot 2017-11-26 at 4 12 15 pm" src="https://user-images.githubusercontent.com/1114467/33246031-caacf742-d2c4-11e7-83a1-935c6ef2b83b.png">
<img width="1312" alt="screen shot 2017-11-26 at 4 12 25 pm" src="https://user-images.githubusercontent.com/1114467/33246032-cacdfbcc-d2c4-11e7-9ac2-deceb098164c.png">

**issue:**
internal task t23481323